### PR TITLE
Moves the Add Item TexdtField up with the keyboard

### DIFF
--- a/nwhacks-2024.xcodeproj/project.pbxproj
+++ b/nwhacks-2024.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		17C59A382DC2F72400D9DBFE /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C59A372DC2F72300D9DBFE /* User.swift */; };
 		17C59A3A2DC2F89200D9DBFE /* Pet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C59A392DC2F89000D9DBFE /* Pet.swift */; };
 		17C59A3C2DC31D0600D9DBFE /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C59A3B2DC31D0000D9DBFE /* ColorExtension.swift */; };
+		17DC3D172DFF53CD007D8DB0 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DC3D162DFF53C8007D8DB0 /* Notification.swift */; };
+		17DC3D182DFF588D007D8DB0 /* Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DC3D152DFF53AF007D8DB0 /* Publishers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +94,8 @@
 		17C59A372DC2F72300D9DBFE /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		17C59A392DC2F89000D9DBFE /* Pet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pet.swift; sourceTree = "<group>"; };
 		17C59A3B2DC31D0000D9DBFE /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		17DC3D152DFF53AF007D8DB0 /* Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.swift; sourceTree = "<group>"; };
+		17DC3D162DFF53C8007D8DB0 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,9 +214,11 @@
 		173756412B5CBE2A001EDD18 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				17DC3D162DFF53C8007D8DB0 /* Notification.swift */,
 				17C59A3B2DC31D0000D9DBFE /* ColorExtension.swift */,
 				173756422B5CBE40001EDD18 /* TextStyles.swift */,
 				173756462B5CF5EC001EDD18 /* ShowingSheetKey.swift */,
+				17DC3D152DFF53AF007D8DB0 /* Publishers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -308,6 +314,7 @@
 				173756492B5CFA47001EDD18 /* WelcomeView.swift in Sources */,
 				173756362B5CB604001EDD18 /* DessertItem.swift in Sources */,
 				1737561C2B5C9518001EDD18 /* AppsView.swift in Sources */,
+				17DC3D172DFF53CD007D8DB0 /* Notification.swift in Sources */,
 				173756082B5C5DF6001EDD18 /* PetView.swift in Sources */,
 				173756252B5C968E001EDD18 /* SidesButton.swift in Sources */,
 				17C59A382DC2F72400D9DBFE /* User.swift in Sources */,
@@ -328,6 +335,7 @@
 				173756232B5C965A001EDD18 /* SpecialsView.swift in Sources */,
 				1737560A2B5C5E19001EDD18 /* TaskView.swift in Sources */,
 				1737561F2B5C95DC001EDD18 /* SidesView.swift in Sources */,
+				17DC3D182DFF588D007D8DB0 /* Publishers.swift in Sources */,
 				173755F82B5C4FEE001EDD18 /* nwhacks_2024App.swift in Sources */,
 				173756512B5D7E00001EDD18 /* SaveButtonNewStyle.swift in Sources */,
 				17C59A302DC2EFC100D9DBFE /* DescribableItem.swift in Sources */,

--- a/nwhacks-2024/Extensions/Notification.swift
+++ b/nwhacks-2024/Extensions/Notification.swift
@@ -1,0 +1,13 @@
+//
+//  Notification.swift
+//  nwhacks-2024
+//
+//  Created by Cindy Cui on 2025-06-15.
+//
+import UIKit
+
+extension Notification {
+    var keyboardHeight: CGFloat {
+        (userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect)?.height ?? 0
+    }
+}

--- a/nwhacks-2024/Extensions/Publishers.swift
+++ b/nwhacks-2024/Extensions/Publishers.swift
@@ -1,0 +1,21 @@
+//
+//  Publishers.swift
+//  nwhacks-2024
+//
+//  Created by Cindy Cui on 2025-06-15.
+//
+import Combine
+import UIKit
+
+enum KeyboardPublisher {
+    static var height: AnyPublisher<CGFloat, Never> {
+        let willShow = NotificationCenter.default.publisher(for: UIApplication.keyboardWillShowNotification)
+            .map { $0.keyboardHeight }
+
+        let willHide = NotificationCenter.default.publisher(for: UIApplication.keyboardWillHideNotification)
+            .map { _ in CGFloat(0) }
+
+        return Publishers.MergeMany(willShow, willHide)
+            .eraseToAnyPublisher()
+    }
+}

--- a/nwhacks-2024/Views/ItemView.swift
+++ b/nwhacks-2024/Views/ItemView.swift
@@ -7,12 +7,14 @@
 
 import SwiftUI
 import SwiftData
+import Combine
+import UIKit
 
 struct ItemView<ItemType: PersistentModel>: View where ItemType: Identifiable {
     @Environment(Pet.self) var pet
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
-    @Query private var items: [ItemType]
+    @Query private var items: [ItemType] // TODO: items aren't shown in chronologically-added order
     
     var title: String
     var subtitle: String
@@ -21,6 +23,7 @@ struct ItemView<ItemType: PersistentModel>: View where ItemType: Identifiable {
     
     @State private var isAddingItem = false
     @State private var itemToAdd = ""
+    @State private var keyboardHeight: CGFloat = 0
     @FocusState private var isAddItemFocused: Bool
     
     var body: some View {
@@ -41,6 +44,8 @@ struct ItemView<ItemType: PersistentModel>: View where ItemType: Identifiable {
             }
             .containerRelativeFrame([.horizontal, .vertical])
             .background(pet.backgroundColor)
+            .padding(.bottom, keyboardHeight)
+            .onReceive(KeyboardPublisher.height) { self.keyboardHeight = $0 }
         } detail: {
             Text("Select an item")
         }
@@ -63,7 +68,7 @@ struct ItemView<ItemType: PersistentModel>: View where ItemType: Identifiable {
         .scrollContentBackground(.hidden)
     }
     
-    var addingItemView: some View { // TODO: lots of warnings + keyboard isnt right
+    var addingItemView: some View {
         Form {
             Section(header: Text("Item to Add")) {
                 HStack {


### PR DESCRIPTION
- Prevents the TextField from being hidden by the keyboard when adding a new item 
- To test, add a new item and confirm that the "item to add" text field still shows above the keyboard, then dismises when hitting 'done'